### PR TITLE
allow python 3 use

### DIFF
--- a/autoload/colorv/colorv.py
+++ b/autoload/colorv/colorv.py
@@ -226,7 +226,7 @@ def nametxt2hex(txt):
     return hex_list 
 def txt2hex(txt): 
     hex_list=[]
-    for fm,reg in fmt.iteritems():
+    for fm,reg in fmt.items():
         for obj in reg.finditer(txt):
             alp = 1
             if fm=="HEX":


### PR DESCRIPTION
Benefits:
The reason for this small change is just to prevent seeing an error at every ColorV load when using +python3, which seems to be a logical continuation of how ColorV has started to support +python3 for users who use that or switch back and forth. 
Also, this would close issue #22. 

Costs:
I don't think this change should have any major tradeoff, or harm +python (2) support in any way. The possible reason to use iteritems() here instead of items() is to get an iterator, which is useful if we have a large number of items that we need to process lazily only a few at a time. But I found that there were 12 items in my 'fmt.' Also, they are all hardcoded, and I cannot think of any reason why more than a few more would ever be added. So it is not likely that this patch will ever have a noticeable effect on Python 2, and the iterator behavior will be used in Python 3 anyway. I have also been using this patch for a while and have not noticed any difference except that it loads instead of throwing the error.