### PR TITLE
Add truecolor support for neovim

### DIFF
--- a/autoload/colorv.vim
+++ b/autoload/colorv.vim
@@ -35,7 +35,10 @@ let s:ColorV.name="_ColorV_".g:colorv.version
 let s:ColorV.listname="_ColorVList_".g:colorv.version
 let g:_colorv = s:ColorV
 let s:size = "mid"
-let s:mode = has("gui_running") || (has("termtruecolor") && &guicolors == 1) ? "gui" : "cterm"
+let s:mode = has("gui_running")
+            \ || (has("termtruecolor") && &guicolors == 1)
+            \ || (has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR == 1)
+            \ ? "gui" : "cterm"
 let s:path = expand('<sfile>:p:h').'/'
 let g:_colorv['size'] = s:size
 let g:_colorv['mode'] = s:mode


### PR DESCRIPTION
Enables 24-bit truecolor support in terminal Neovim.